### PR TITLE
Add additional option to allow setting custom http headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ var uploader = new Uploader({ ... });
 - `name`: Name of the FormData param used for upload. Default: `file`.
 - `url`: URL of your server-side upload API endpoint. If omitted, calling upload() will throw or emit and error.
 - `method`: Request method used during upload. Default: `POST`.
+- `headers`: An optional object with headers to be set on the XHR object before sending,  e.g. `{'X-CSRFToken': token}` 
 
 
 ### Public methods

--- a/examples/single.js
+++ b/examples/single.js
@@ -16,7 +16,8 @@ module.exports = function() {
 
   var single = new Uploader({
     el: '#input-single',
-    url: '/upload'
+    url: '/upload',
+    headers: {testheader: "testval", testheader2: null}
   });
 
   var t = template('<p> \

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,18 @@ module.exports = Uploader;
 
 
 // uploader
-
+/**
+ *
+ * @param options
+ * @param options.el required. Can be a DOM reference or a CSS selector. Supported tags
+ *        are input (classic file input) or a div (for drag & drop)
+ * @param options.name Name of the FormData param used for upload. Default: file
+ * @param options.url URL of your server-side upload API endpoint. If omitted, calling upload()
+ *        will throw or emit and error
+ * @param options.method Request method used during upload. Default: POST
+ * @param options.headers object of headers to be set on the XHR object before sending
+ * @constructor
+ */
 function Uploader(options) {
 
   if (typeof options !== 'object') {
@@ -36,12 +47,17 @@ function Uploader(options) {
     throw new TypeError('options `method` must be a string');
   }
 
+  if (options.headers && typeof options.headers !== 'object') {
+    throw new TypeError('options `headers` must be an object');
+  }
+
   //
 
   this.files = [];
   this.method = options.method || 'POST';
   this.name = options.name || 'file';
   this.url = options.url || null;
+  this.headers = options.headers || {};
 
   // EE3
 
@@ -240,6 +256,11 @@ Uploader.prototype._upload = function() {
 
   var xhr = new XMLHttpRequest();
   xhr.open(this.method.toUpperCase(), this.url);
+
+  // set custom headers if specified
+  for(var key in this.headers) {
+    xhr.setRequestHeader(key, this.headers[key] || "");
+  }
 
   xhr.onerror = function() {
     var message = this.statusText || 'upload failed';

--- a/package.json
+++ b/package.json
@@ -23,11 +23,12 @@
     "express": "^4.9.8",
     "humanize": "0.0.9",
     "mocha": "^1.21.5",
+    "multer": "^0.1.6",
     "should": "^4.0.4",
     "supervisor": "^0.6.0",
+    "uglify-js": "^2.4.15",
     "underscore": "^1.7.0",
-    "multer": "^0.1.6",
-    "uglify-js": "^2.4.15"
+    "watchify": "^3.3.1"
   },
   "keywords": [
     "html5",

--- a/test/public/tests.js
+++ b/test/public/tests.js
@@ -70,7 +70,7 @@ describe('Uploader', function() {
   });
 
 
-  it('Should have defaults for method, name, url', function() {
+  it('Should have defaults for method, name, url, headers', function() {
     var $div = document.createElement('div');
 
     var uploader = new Uploader({
@@ -79,6 +79,7 @@ describe('Uploader', function() {
 
     uploader.method.should.be.equal('POST');
     uploader.name.should.be.equal('file');
+    uploader.headers.should.containEql({});
     Should(uploader.url === null).be.true;
   });
 
@@ -136,6 +137,31 @@ describe('Uploader', function() {
       var data = JSON.parse(res);
       data.status.should.equal('ok');
 
+      done();
+    });
+
+    uploader.upload();
+  });
+
+  it('Should include custom headers', function(done) {
+    var $div = document.createElement('div');
+
+    var headers = {
+      'x-csrftoken': 'abcd1234',
+      'authorization': 'Bearer 0abc27767863beff6487368847ef'
+    };
+
+    var uploader = new Uploader({
+      el: $div,
+      url: '/upload/returnheaders',
+      headers: headers
+    });
+
+    uploader.files.push(mockFile());
+
+    uploader.on('upload:done', function(res) {
+      var data = JSON.parse(res);
+      data.headers.should.have.properties(headers);
       done();
     });
 

--- a/test/server.js
+++ b/test/server.js
@@ -24,6 +24,10 @@ app.post('/upload', function(req, res) {
   res.json({ status: 'ok'});
 });
 
+app.post('/upload/returnheaders', function(req, res) {
+  res.json({headers: req.headers});
+});
+
 app.listen(3000, function() {
   console.log('Test server listening on port 3000');
 });


### PR DESCRIPTION
This can e.g. be used to set CSRF tokens or authentication headers.